### PR TITLE
Remove redundant lines under package requirements

### DIFF
--- a/recipes/cylc-flow/meta.yaml
+++ b/recipes/cylc-flow/meta.yaml
@@ -29,7 +29,6 @@ requirements:
     - ansimarkup>=1.0.0
     - graphene==2.1.6
     - protobuf>=3.7
-    - python-jose>=3.0
   run:
     - python >3
     - colorama>=0.4
@@ -41,7 +40,6 @@ requirements:
     - ansimarkup>=1.0.0
     - graphene==2.1.6
     - protobuf>=3.7
-    - python-jose>=3.0
     - cryptography
     - pyasn1
 


### PR DESCRIPTION
I noticed there are identical lines under each of the ``host`` & ``run`` sections for the ``cylc-flow`` package requirements in the conda overarching recipe. These can obviously be removed without any influence on the recipe build behaviour.

From this, I was wondering if it would perhaps be sensible to list packages under such sections in alphabetical order (or perhaps those with definitive version ranges listed alphabetically, then those without alphabetically, or similar) to make it easier to pick out packages, & prevent any duplication in future, when lists may be extended?

Trivial, hence one reviewer sufficient.