### PR TITLE
Update URLs, checksums, and build numbers for 8.0a1 release

### DIFF
--- a/recipes/cylc-flow/meta.yaml
+++ b/recipes/cylc-flow/meta.yaml
@@ -6,13 +6,11 @@ package:
   version: "{{ version }}"
 
 source:
-  #git_url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
-  #sha256: "3588bef608d5bbd7911c627f88dbfad7c0553820be77317fa0b631201db43ba0"
-  git_url: https://github.com/cylc/cylc-flow.git
-  git_rev: bb5a1270e5a695e4a69c4f0d476d1c00d17ae81f
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: "36f4f4363cb5cc7a3a613d2db6e84cc41c2825c6cd011191cc4821c5ca9c81a4"
 
 build:
-  number: 2
+  number: 3
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "
 
 requirements:

--- a/recipes/cylc-uiserver/meta.yaml
+++ b/recipes/cylc-uiserver/meta.yaml
@@ -1,16 +1,16 @@
 {% set name = "cylc-uiserver" %}
-{% set version = "1.0" %}
+{% set version = "0.1" %}
 
 package:
   name: "{{ name|lower }}"
   version: "{{ version }}"
 
 source:
-  git_url: https://github.com/cylc/cylc-uiserver.git
-  git_rev: 840d102653f1412895a045fb233f1917a06872a2
+  url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
+  sha256: "4cc85a6680148cddd8f1fd714f772acb7c52487239b7c2b781bf543a51c099d1"
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - cylc-uiserver=cylc.uiserver.main:main
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv "

--- a/recipes/cylc/meta.yaml
+++ b/recipes/cylc/meta.yaml
@@ -1,10 +1,10 @@
 {% set name = "cylc" %}
-{% set version = "8.0" %}
+{% set version = "8.0a1" %}
 # Cylc Xtriggers
 #{% set xtriggers_hash = "a83eb011021cf67f96e79c14f4e003fa7d3f2ab8" %}
 # Cylc UI
-{% set ui_version = "0.6-special" %}
-{% set ui_hash = "f5a8dccf29ae304e0871434aaad25540c5c159f641997d0b66c5d89a0669724d" %}
+{% set ui_version = "0.1" %}
+{% set ui_hash = "639b18bb7526914203ffdc6bd80f2b580683c63e3d94c4b92d1bb00355824b44" %}
 
 package:
   name: '{{ name|lower }}'
@@ -12,21 +12,21 @@ package:
 
 source:
   # Cylc UI
-  - url: https://github.com/kinow/cylc-ui/releases/download/{{ ui_version }}/cylc-ui-{{ ui_version }}-dist.zip
+  - url: https://github.com/cylc/cylc-ui/releases/download/{{ ui_version }}/cylc-ui-{{ ui_version }}-dist.zip
     sha256: {{ ui_hash }}
     folder: cylc-ui
 
 build:
   # Skip as Cylc requires Linux
   skip: True  # [not linux]
-  number: 1
+  number: 2
 
 requirements:
   host:
     - python >=3.7
   run:
     - cylc-flow==8.0a1
-    - cylc-uiserver==1.0
+    - cylc-uiserver==0.1
     - python >=3.7
     - 'configurable-http-proxy >=4.1'
 


### PR DESCRIPTION
There was one build number that I updated recently, without uploading. But since build numbers are not that important, to play safe I'm updating all build numbers for the recipes modified here.

Tested locally by re-building these three recipes in the following order: cylc-uiserver, cylc-flow, cylc. The test was done with `conda build .`, followed by `conda install --use-local $package-name`, where `$package-name` values are cylc-uiserver, cylc-flow, and cylc.

Confirmed these were installed successfully on my newly created `cylc1` (deleted it before starting) with `conda list | grep cylc`:

![image](https://user-images.githubusercontent.com/304786/65285795-9f3fa500-db91-11e9-824a-35b39ae91797.png)

Final test was running `jupyterhub --JupyterHub.spawner_class="jupyterhub.spawner.LocalProcessSpawner" --Spawner.args="['-s', '${CONDA_PREFIX}/work/cylc-ui']" --Spawner.cmd="cylc-uiserver" --JupyterHub.logo_file="${CONDA_PREFIX}/work/cylc-ui/img/logo.png"`.

Which failed and almost gave me a heart attack, but it was actually because I was already running the hub in a virtualenv. Stopped that hub, and tried again. This time it started with no issues.

Then opened a new terminal and activated the `cylc1` conda environment. And started my workflow five. Final test: http://localhost:8000. Logged in, Cylc UI started fine, though there is a strange error on the browser console.

After some investigation, found out that it was installing cylc 8.0. Turns out **conda keeps build packages in a folder common to all environments**. So I got:

![image](https://user-images.githubusercontent.com/304786/65287617-f183c480-db97-11e9-9fbd-e558048c1165.png)

The version 8.0 was built before during tests, some days ago. And running `conda install --use-local picks up the full version as it is greater than the alpha one. Fixed by specifying cylc==8.0a1 in conda.

Then once again, the Cylc UI was broken. But this time, the ZIP file was extracted, but only the files at the root directory were put in the conda build file. I checked the ZIP on GitHub, and it contains everything.

## From scratch

1. deleted everything under /home/kinow/anaconda3/envs/
2. deleted everything under /home/kinow/anaconda3/conda-bld/
3. conda build && conda install --use-local again everything
4. It failed gain.

Then I download the cylc-ui-0.1.zip from the release again, had a look inside. The folders were there... but were empty....

![iWKad22](https://user-images.githubusercontent.com/304786/65288881-8d173400-db9c-11e9-97aa-46830600fef6.jpg)

Once fixed, everything worked fine. Whew!